### PR TITLE
Add support for gitlab subgroups

### DIFF
--- a/ci-tooling/lib/projects/factory/gitlab.rb
+++ b/ci-tooling/lib/projects/factory/gitlab.rb
@@ -75,11 +75,8 @@ class ProjectsFactory
                          .auto_paginate
                          .collect(&:path_with_namespace)
         repos += ::Gitlab.group_subgroups(group_id).auto_paginate.collect do |subgroup|
-			list_repos(subgroup.id)
-        end
           repos += list_repos(subgroup.id)
         end
-        return repos
       end
     end
   end

--- a/ci-tooling/lib/projects/factory/gitlab.rb
+++ b/ci-tooling/lib/projects/factory/gitlab.rb
@@ -44,7 +44,7 @@ class ProjectsFactory
     # FIXME: same as in Neon except component is merged
     def split_entry(entry)
       parts = entry.split('/')
-      group = parts[0]
+      group = parts.length > 2 ? parts[0] : ""
       name = parts[-1]
       component = parts[-2] || 'gitlab'
       [name, component, group]

--- a/ci-tooling/lib/projects/factory/gitlab.rb
+++ b/ci-tooling/lib/projects/factory/gitlab.rb
@@ -44,7 +44,7 @@ class ProjectsFactory
     # FIXME: same as in Neon except component is merged
     def split_entry(entry)
       parts = entry.split('/')
-      group = parts.length > 2 ? parts[0] : ""
+      group = parts.length > 2 ? parts[0] : ''
       name = parts[-1]
       component = parts[-2] || 'gitlab'
       [name, component, group]

--- a/ci-tooling/lib/projects/factory/gitlab.rb
+++ b/ci-tooling/lib/projects/factory/gitlab.rb
@@ -54,7 +54,7 @@ class ProjectsFactory
       default_params.merge(
         name: name,
         component: component,
-        url_base: self.class.url_base + '/' + group
+        url_base: "#{self.class.url_base}/#{group}"
       )
     end
 

--- a/ci-tooling/lib/projects/factory/gitlab.rb
+++ b/ci-tooling/lib/projects/factory/gitlab.rb
@@ -41,7 +41,6 @@ class ProjectsFactory
 
     private
 
-    # FIXME: same as in Neon except component is merged
     def split_entry(entry)
       parts = entry.split('/')
       group = parts.length > 2 ? parts[0] : ''
@@ -69,10 +68,9 @@ class ProjectsFactory
         repos = ::Gitlab.group_projects(base_id).auto_paginate.collect(&:path)
         ::Gitlab.group_subgroups(base_id).auto_paginate.each do |subgroup|
           ::Gitlab.group_projects(subgroup.id).each do |repo|
-            repos << subgroup.path + '/' + repo.path
+            repos << "#{subgroup.path}/#{repo.path}"
           end
         end
-        puts repos
         @list_cache[base] = repos.freeze
       end
     end

--- a/ci-tooling/lib/projects/factory/gitlab.rb
+++ b/ci-tooling/lib/projects/factory/gitlab.rb
@@ -74,7 +74,9 @@ class ProjectsFactory
         repos += ::Gitlab.group_projects(group_id)
                          .auto_paginate
                          .collect(&:path_with_namespace)
-        ::Gitlab.group_subgroups(group_id).auto_paginate.each do |subgroup|
+        repos += ::Gitlab.group_subgroups(group_id).auto_paginate.collect do |subgroup|
+			list_repos(subgroup.id)
+        end
           repos += list_repos(subgroup.id)
         end
         return repos

--- a/ci-tooling/test/test_projects_factory.rb
+++ b/ci-tooling/test/test_projects_factory.rb
@@ -452,6 +452,13 @@ hello sitter, this is gitolite3@weegie running gitolite3 3.6.1-3 (Debian) on git
     assert_equal 'git', project.packaging_scm.type
     assert_equal "#{gitlab_dir}/calamares/neon/neon-pinebook", project.packaging_scm.url
     assert_equal 'kubuntu_unstable', project.packaging_scm.branch
+
+    project = projects[2]
+    refute_equal(project, nil)
+    assert_equal 'oem-config', project.name
+    assert_equal 'git', project.packaging_scm.type
+    assert_equal "#{gitlab_dir}/calamares/neon/oem/oem-config", project.packaging_scm.url
+    assert_equal 'kubuntu_unstable', project.packaging_scm.branch
   end
 
   def test_launchpad_understand

--- a/ci-tooling/test/test_projects_factory.rb
+++ b/ci-tooling/test/test_projects_factory.rb
@@ -395,7 +395,7 @@ hello sitter, this is gitolite3@weegie running gitolite3 3.6.1-3 (Debian) on git
   end
 
   def test_gitlab_from_list
-    gitlab_repos = %w(calamares/calamares-debian calamares/calamares-debian/neon/neon-pinebook)
+    gitlab_repos = %w(calamares/calamares-debian calamares/neon/neon-pinebook)
     gitlab_dir = create_fake_git(branches: %w(master kubuntu_unstable),
                                  repos: gitlab_repos)
     ProjectsFactory::Gitlab.instance_variable_set(:@url_base, gitlab_dir)
@@ -411,7 +411,7 @@ hello sitter, this is gitolite3@weegie running gitolite3 3.6.1-3 (Debian) on git
       ::Gitlab::PaginatedResponse.new([resource.new('calamares-debian')])
 
     subgroup_projects =
-      ::Gitlab::PaginatedResponse.new([resource.new('calamares-pinebook')])
+      ::Gitlab::PaginatedResponse.new([resource.new('neon-pinebook')])
 
 
     ::Gitlab.expects(:group_projects)
@@ -438,9 +438,9 @@ hello sitter, this is gitolite3@weegie running gitolite3 3.6.1-3 (Debian) on git
 
     project = projects[1]
     refute_equal(project, nil)
-    assert_equal 'calamares-pinebook', project.name
+    assert_equal 'neon-pinebook', project.name
     assert_equal 'git', project.packaging_scm.type
-    assert_equal "#{gitlab_dir}/calamares/calamares-debian/neon/neon-pinebook", project.packaging_scm.url
+    assert_equal "#{gitlab_dir}/calamares/neon/neon-pinebook", project.packaging_scm.url
     assert_equal 'kubuntu_unstable', project.packaging_scm.branch
   end
 


### PR DESCRIPTION
rubocop is still broken, but don't really have good ideas to solve them

```
ci-tooling/lib/projects/factory/gitlab.rb:63:7: C: Metrics/AbcSize: Assignment Branch Condition size for ls is too high. [21.61/15]
ci-tooling/lib/projects/factory/gitlab.rb:63:7: C: Metrics/MethodLength: Method has too many lines. [11/10]
```