### PR TITLE
Don't build mgmt_docker jobs on the neon CI

### DIFF
--- a/jenkins_jobs_update_nci.rb
+++ b/jenkins_jobs_update_nci.rb
@@ -22,8 +22,6 @@
 # To only update some jobs run on drax with e.g.
 # NO_UPDATE=1 UPDATE_INCLUDE='_calamares_' ./tooling/jenkins_jobs_update_nci.rb
 
-require 'etc'
-
 require_relative 'ci-tooling/lib/nci'
 require_relative 'ci-tooling/lib/projects/factory'
 require_relative 'lib/jenkins/project_updater'
@@ -328,7 +326,6 @@ class ProjectUpdater < Jenkins::ProjectUpdater
                                        type: 'user-lts',
                                        dist: NCI.future_series))
     enqueue(MGMTJenkinsPruneParameterListJob.new)
-    enqueue(MGMTJenkinsArchive.new)
     enqueue(MGMTGitSemaphoreJob.new)
     enqueue(MGMTJobUpdater.new)
     enqueue(MGMTDigitalOcean.new)

--- a/jenkins_jobs_update_nci.rb
+++ b/jenkins_jobs_update_nci.rb
@@ -22,6 +22,8 @@
 # To only update some jobs run on drax with e.g.
 # NO_UPDATE=1 UPDATE_INCLUDE='_calamares_' ./tooling/jenkins_jobs_update_nci.rb
 
+require 'etc'
+
 require_relative 'ci-tooling/lib/nci'
 require_relative 'ci-tooling/lib/projects/factory'
 require_relative 'lib/jenkins/project_updater'
@@ -313,7 +315,6 @@ class ProjectUpdater < Jenkins::ProjectUpdater
     enqueue(MGMTPauseIntegrationJob.new(downstreams: [progenitor]))
     enqueue(MGMTAptlyJob.new(dependees: [progenitor]))
     enqueue(MGMTWorkspaceCleanerJob.new(dist: NCI.current_series))
-    docker = enqueue(MGMTDockerJob.new(dependees: []))
     enqueue(MGMTMergerDebianFrameworks.new)
     enqueue(MGMTGerminateJob.new(dist: NCI.current_series))
     enqueue(MGMTAppstreamHealthJob.new(dist: NCI.current_series))
@@ -375,7 +376,7 @@ class ProjectUpdater < Jenkins::ProjectUpdater
     enqueue(MGMTRepoUndoDivert.new(target: 'stable_bionic'))
     enqueue(MGMTRepoUndoDivert.new(target: 'stable_xenial'))
 
-    enqueue(MGMTToolingJob.new(downstreams: [docker],
+    enqueue(MGMTToolingJob.new(downstreams: [],
                                dependees: []))
     enqueue(MGMTRepoCleanupJob.new)
   end


### PR DESCRIPTION
suggestion was to put it only if user is jenkins. But I see no usecase
of the condition? We likely won't be using mgmt_docker on charlotte,
while on drax, we can keep the current mgmt_docker job as it is.