### PR TITLE
make sure symlinks are not uploaded

### DIFF
--- a/nci/imager_push.rb
+++ b/nci/imager_push.rb
@@ -135,6 +135,11 @@ Net::SFTP.start('master.kde.org', 'neon', *ssh_args) do |sftp|
   types = %w[.iso .iso.sig manifest zsync zsync.README sha256sum]
   types.each do |type|
     Dir.glob("result/*#{type}").each do |file|
+      # Skip over current symlinks, we'll recreate them on the remote.
+      # They'd only trip up sftp uploads as symlinks being preserved is a bit
+      # hit and miss.
+      next if File.symlink?(file)
+
       name = File.basename(file)
       sftp.cli_uploads = File.new(file).lstat.size > 4 * 1024 * 1024
       STDERR.puts "Uploading #{file} (via cli: #{sftp.cli_uploads})... "


### PR DESCRIPTION
they get resolved to blobs and in any event we do create them over ssh
anyway, so simply skip over all symlinks.

adjust test case to
a) have a fixture symlink
b) make sure upload! always flattens symlinks
c) assert the files that should be symlinks are in fact there
d) also make sure zsync is there (previously was left out of fixtures)