### PR TITLE
Remove unavailable syslinux-themes-ubuntu

### DIFF
--- a/nci/imager/build.sh
+++ b/nci/imager/build.sh
@@ -78,7 +78,7 @@ DATE="${_DATE}${_TIME}"
 # Somewhere in utopic things fell to shit, so lb doesn't pack all files necessary
 # for isolinux on the ISO. Why it happens or how or what is unknown. However linking
 # the required files into place seems to solve the problem. LOL.
-sudo apt install -y --no-install-recommends  syslinux-themes-ubuntu syslinux-themes-neon
+sudo apt install -y --no-install-recommends syslinux-themes-neon
 # sudo ln -s /usr/lib/syslinux/modules/bios/ldlinux.c32 /usr/share/syslinux/themes/ubuntu-$DIST/isolinux-live/ldlinux.c32
 # sudo ln -s /usr/lib/syslinux/modules/bios/libutil.c32 /usr/share/syslinux/themes/ubuntu-$DIST/isolinux-live/libutil.c32
 # sudo ln -s /usr/lib/syslinux/modules/bios/libcom32.c32 /usr/share/syslinux/themes/ubuntu-$DIST/isolinux-live/libcom32.c32


### PR DESCRIPTION
`syslinux-themes-ubuntu` doesn't exist anymore in Jammy. This breaks the ISO build for Jammy. Since we install `syslinux-themes-neon` which we built ourselves anyways, we can most likely remove `syslinux-themes-ubuntu` wiithout negative consequences.

Might break ISO CI for focal.