### PR TITLE
Remove unavailable gfxboot-theme-ubuntu

### DIFF
--- a/nci/imager/ubuntu-defaults-image
+++ b/nci/imager/ubuntu-defaults-image
@@ -194,7 +194,7 @@ fi
 # make autobuilds reliable.
 case $ARCH in
     *amd64|*i386)
-	$SUDO apt-get -y install gfxboot-theme-ubuntu memtest86+ syslinux || exit 1
+	$SUDO apt-get -y install memtest86+ syslinux || exit 1
 	;;
 esac
 $SUDO apt-get -y install genisoimage


### PR DESCRIPTION
Like in #35, this package is no longer available in jammy. Removing it should hopefully fix the Jammy ISO CI.