### PR TITLE
Revert removal of gfxboot and syslinux-themes

### DIFF
--- a/nci/imager/build.sh
+++ b/nci/imager/build.sh
@@ -78,12 +78,7 @@ DATE="${_DATE}${_TIME}"
 # Somewhere in utopic things fell to shit, so lb doesn't pack all files necessary
 # for isolinux on the ISO. Why it happens or how or what is unknown. However linking
 # the required files into place seems to solve the problem. LOL.
-if [ $DIST = "jammy" ]; then
-    sudo apt install -y --no-install-recommends syslinux-themes-neon
-else
-    sudo apt install -y --no-install-recommends syslinux-themes-ubuntu syslinux-themes-neon
-
-fi
+sudo apt install -y --no-install-recommends syslinux-themes-ubuntu syslinux-themes-neon
 # sudo ln -s /usr/lib/syslinux/modules/bios/ldlinux.c32 /usr/share/syslinux/themes/ubuntu-$DIST/isolinux-live/ldlinux.c32
 # sudo ln -s /usr/lib/syslinux/modules/bios/libutil.c32 /usr/share/syslinux/themes/ubuntu-$DIST/isolinux-live/libutil.c32
 # sudo ln -s /usr/lib/syslinux/modules/bios/libcom32.c32 /usr/share/syslinux/themes/ubuntu-$DIST/isolinux-live/libcom32.c32

--- a/nci/imager/ubuntu-defaults-image
+++ b/nci/imager/ubuntu-defaults-image
@@ -194,11 +194,7 @@ fi
 # make autobuilds reliable.
 case $ARCH in
     *amd64|*i386)
-        if [ $SUITE = "jammy" ]; then
-            $SUDO apt-get -y install memtest86+ syslinux || exit 1
-        else
-            $SUDO apt-get -y install gfxboot-theme-ubuntu memtest86+ syslinux || exit 1
-        fi
+        $SUDO apt-get -y install gfxboot-theme-ubuntu memtest86+ syslinux || exit 1
     ;;
 esac
 $SUDO apt-get -y install genisoimage


### PR DESCRIPTION
Since we are now building these packages ourselves for jammy, we can include them again in the list of packages to be installed. This should also fix one of the issues with the ISO build (missing gfxboot-theme-ubuntu files).