### PR TITLE
naive attempt to allow qml6 to be linted as well

### DIFF
--- a/lib/ci/kcrash_link_validator.cmake
+++ b/lib/ci/kcrash_link_validator.cmake
@@ -75,7 +75,7 @@ function(kcrash_validator_check_all_targets)
             message("KCrash validating: ${target}")
             add_custom_target(objdump-kcrash-${target} ALL
                 COMMAND echo "  $<TARGET_FILE:${target}>"
-                COMMAND objdump -p $<TARGET_FILE:${target}> | grep NEEDED | grep libKF5Crash.so
+                COMMAND objdump -p $<TARGET_FILE:${target}> | grep NEEDED | grep libKF.Crash.so
                 DEPENDS ${target}
                 COMMENT "Checking if target linked KCrash: ${target}")
         endforeach()

--- a/lib/qml/module.rb
+++ b/lib/qml/module.rb
@@ -3,7 +3,8 @@ require_relative '../dpkg'
 
 # Management construct for QML related bits.
 module QML
-  SEARCH_PATHS = ["/usr/lib/#{DPKG::HOST_MULTIARCH}/qt5/qml"].freeze
+  # Qt6 Hack
+    SEARCH_PATHS = ["/usr/lib/#{DPKG::HOST_MULTIARCH}/qt5/qml", "/usr/lib/#{DPKG::HOST_MULTIARCH}/qt6/qml"].freeze
 
   # Describes a QML module.
   class Module


### PR DESCRIPTION
https://build.neon.kde.org/job/jammy_unstable_qt6_qt6-declarative_lintqml/11/console

qt6-declarative is failing the qml lint tests.  currently only the qt5 path is passed to the array but it is an array so lets pass the qt6 path as well and hope everything doesn't explode too much