### PR TITLE
temporarily remove libjpeg-turbo from i386

### DIFF
--- a/jenkins-jobs/nci/project.rb
+++ b/jenkins-jobs/nci/project.rb
@@ -32,7 +32,7 @@ class ProjectJob < JenkinsJob
     return [] unless project.debian?
 
     architectures = architectures.dup
-    architectures << 'i386' if %w[chafa-jammy libjpeg-turbo-jammy harfbuzz util-linux wayland libdrm-jammy libdrm lcms2-jammy wayland-jammy].any? { |x| project.name == x }
+    architectures << 'i386' if %w[chafa-jammy harfbuzz util-linux wayland libdrm-jammy libdrm lcms2-jammy wayland-jammy].any? { |x| project.name == x }
 
     basename = basename(distribution, type, project.component, project.name)
 


### PR DESCRIPTION
while i rebuild the jpeg dep chain with the new merge from ubuntu.  once all is well again in jpegland we can revert it and build the needed i386 package.