### PR TITLE
make rake happy with ruby 3.0.0 by using Minitest::

### DIFF
--- a/nci/lint/upgrade_versions.rb
+++ b/nci/lint/upgrade_versions.rb
@@ -195,7 +195,7 @@ module NCI
   # It then constructs concurrent promises checking if these packages'
   # versions are greater than the ones we have presently available in
   # the system.
-  class VersionsTest < MiniTest::Test
+  class VersionsTest < Minitest::Test
     parallelize_me!
 
     class << self

--- a/nci/lint/versions.rb
+++ b/nci/lint/versions.rb
@@ -35,7 +35,7 @@ module NCI
   # `name` and `version` attributes describing the packages we have.
   # It then constructs checks if these packages' versions are greater than
   #  the ones we have presently available in the system.
-  class VersionsTest < MiniTest::Test
+  class VersionsTest < Minitest::Test
     parallelize_me!
 
     class << self


### PR DESCRIPTION
<module:NCI>': uninitialized constant NCI::MiniTest (NameError)
