### PR TITLE
push jenkins_expunge back 2 hours

### DIFF
--- a/jenkins-jobs/nci/templates/mgmt_jenkins_expunge.xml.erb
+++ b/jenkins-jobs/nci/templates/mgmt_jenkins_expunge.xml.erb
@@ -16,7 +16,7 @@
   <blockBuildWhenUpstreamBuilding>true</blockBuildWhenUpstreamBuilding>
   <triggers>
     <hudson.triggers.TimerTrigger>
-      <spec>4 H * * *</spec>
+      <spec>6 H * * *</spec>
     </hudson.triggers.TimerTrigger>
   </triggers>
   <concurrentBuild>false</concurrentBuild>


### PR DESCRIPTION
due to the volume of build jobs nowadays expunge regular blocks the build