### PR TITLE
add dynamic blacklist allowing indep-builds for qt6* on arm

### DIFF
--- a/lib/ci/package_builder.rb
+++ b/lib/ci/package_builder.rb
@@ -248,7 +248,15 @@ rebuild of *all* related sources (e.g. all of Qt) *after* all sources have built
     end
 
     def arch_bin_only?
-      value = ENV.fetch('PANGEA_ARCH_BIN_ONLY', 'true')
+      control = Debian::Control.new(Dir.pwd)
+      control.parse!
+      source_name = control.source.fetch('Source', '')
+      source_name = source_name.sub!(/qt6-/, '')
+      if source_name= nil
+        value = ENV.fetch('PANGEA_ARCH_BIN_ONLY', 'true')
+      else
+        value = ENV.fetch('PANGEA_ARCH_BIN_ONLY', 'false')
+      end
       case value.downcase
       when 'true', 'on'
         return true

--- a/lib/ci/package_builder.rb
+++ b/lib/ci/package_builder.rb
@@ -248,6 +248,8 @@ rebuild of *all* related sources (e.g. all of Qt) *after* all sources have built
     end
 
     def arch_bin_only?
+      control = Debian::Control.new(Dir.pwd)
+      control.parse!
       if control.source.fetch('Source').start_with?('qt6-')
         value = ENV.fetch('PANGEA_ARCH_BIN_ONLY', 'false')
       else

--- a/lib/ci/package_builder.rb
+++ b/lib/ci/package_builder.rb
@@ -248,14 +248,10 @@ rebuild of *all* related sources (e.g. all of Qt) *after* all sources have built
     end
 
     def arch_bin_only?
-      control = Debian::Control.new(Dir.pwd)
-      control.parse!
-      source_name = control.source.fetch('Source', '')
-      source_name = source_name.sub!(/qt6-/, '')
-      if source_name= nil
-        value = ENV.fetch('PANGEA_ARCH_BIN_ONLY', 'true')
-      else
+      if control.source.fetch('Source').start_with?('qt6-')
         value = ENV.fetch('PANGEA_ARCH_BIN_ONLY', 'false')
+      else
+        value = ENV.fetch('PANGEA_ARCH_BIN_ONLY', 'true')
       end
       case value.downcase
       when 'true', 'on'


### PR DESCRIPTION
currently all non arch builds (ie not amd64) are built bin-only for speed and resources.  however to properly setup qt6 build to bootstrap each major/minor release for docs indep-builds are required.  limit this to qt6 sources with a dynamic blacklist reather than hardcode an array into the code.