### PR TITLE
catch the exception if current doesn't exist

### DIFF
--- a/nci/imager_push.rb
+++ b/nci/imager_push.rb
@@ -214,7 +214,11 @@ Net::SFTP.start('rsync.kde.org', 'neon', *ssh_args) do |sftp|
   sftp.cli_uploads = false
   sftp.upload!('result/.message', "#{REMOTE_PUB_DIR}/.message")
   sftp.remove!("#{REMOTE_DIR}/current")
-  sftp.symlink!("#{DATE}", "#{REMOTE_DIR}/current")
+  begin
+    sftp.remove!("#{REMOTE_DIR}/current")
+  rescue Net::SFTP::StatusException # current doesn't exist
+    puts "#{REMOTE_DIR}/current doesn't exist; not deleting"
+  end
 
   sftp.dir.glob(REMOTE_DIR, '*') do |entry|
     next unless entry.directory? # current is a symlink


### PR DESCRIPTION
on first run the expected current dir/symlink doesn't exist so catch the error