### PR TITLE
only run populate_kde_keyring if it's a kde project

### DIFF
--- a/lib/ci/tar-fetcher/watch.rb
+++ b/lib/ci/tar-fetcher/watch.rb
@@ -74,7 +74,7 @@ module CI
 
     def populate_keyring
       make_dir("#{@dir}/upstream/")
-      FileUtils.cp('/usr/share/keyrings/kde-release-keyring.asc', "#{@dir}/upstream/signing-key.asc", force: true)
+      FileUtils.cp('/usr/share/keyrings/kde-release-keyring.asc', "#{@dir}/upstream/signing-key.asc")
     end
 
     def make_dir(destdir)

--- a/lib/ci/tar-fetcher/watch.rb
+++ b/lib/ci/tar-fetcher/watch.rb
@@ -58,6 +58,7 @@ module CI
       #   without downloading. then decide whether to wipe destdir and download
       #   or not.
       maybe_mangle do
+        populate_keyring()
         make_dir(destdir)
         apt_source(destdir)
         uscan(@dir, destdir) unless @have_source
@@ -70,6 +71,11 @@ module CI
     end
 
     private
+
+    def populate_keyring
+      make_dir("#{@dir}/upstream/")
+      FileUtils.cp('/usr/share/keyrings/kde-release-keyring.asc', "#{@dir}/upstream/signing-key.asc", force: true)
+    end
 
     def make_dir(destdir)
       FileUtils.mkpath(destdir) unless Dir.exist?(destdir)

--- a/lib/ci/tar-fetcher/watch.rb
+++ b/lib/ci/tar-fetcher/watch.rb
@@ -58,7 +58,6 @@ module CI
       #   without downloading. then decide whether to wipe destdir and download
       #   or not.
       maybe_mangle do
-        populate_keyring()
         make_dir(destdir)
         apt_source(destdir)
         uscan(@dir, destdir) unless @have_source
@@ -71,11 +70,6 @@ module CI
     end
 
     private
-
-    def populate_keyring
-      make_dir("#{@dir}/upstream/")
-      FileUtils.cp('/usr/share/keyrings/kde-release-keyring.asc', "#{@dir}/upstream/signing-key.asc")
-    end
 
     def make_dir(destdir)
       FileUtils.mkpath(destdir) unless Dir.exist?(destdir)
@@ -97,6 +91,7 @@ module CI
     def maybe_mangle(&block)
       orig_data = File.read(@watchfile)
       File.write(@watchfile, mangle_url(orig_data)) if @mangle_download
+      populate_kde_keyring()
       block.yield
     ensure
       File.write(@watchfile, orig_data)
@@ -107,6 +102,11 @@ module CI
       # Only available through blue system's internal DNS.
       data.gsub(%r{download.kde.org/stable/},
                 'download.kde.internal.neon.kde.org/stable/')
+    end
+
+    def populate_kde_keyring
+      make_dir("#{@dir}/upstream/")
+      FileUtils.cp('/usr/share/keyrings/kde-release-keyring.asc', "#{@dir}/upstream/signing-key.asc")
     end
 
     def changelog

--- a/nci/lib/setup_repo.rb
+++ b/nci/lib/setup_repo.rb
@@ -59,7 +59,7 @@ module NCI
     # Make sure we have the latest pkg-kde-tools, not whatever is in the image.
     return unless with_install
 
-    raise 'failed to install deps' unless Apt.install(%w[pkg-kde-tools pkg-kde-tools-neon debhelper cmake quilt dh-python dh-translations])
+    raise 'failed to install deps' unless Apt.install(%w[pkg-kde-tools pkg-kde-tools-neon debhelper cmake quilt dh-python dh-translations kde-release-keyring])
 
     # Qt6 Hack
     return unless %w[_qt6_bin_ _qt6_src].any? do |x|


### PR DESCRIPTION
force:true is the default for Fileutils.cp and thus causes an error