### PR TITLE
only run populate_kde_keyring if it's a kde project

### DIFF
--- a/lib/ci/tar-fetcher/watch.rb
+++ b/lib/ci/tar-fetcher/watch.rb
@@ -58,7 +58,6 @@ module CI
       #   without downloading. then decide whether to wipe destdir and download
       #   or not.
       maybe_mangle do
-        populate_keyring()
         make_dir(destdir)
         apt_source(destdir)
         uscan(@dir, destdir) unless @have_source
@@ -72,9 +71,9 @@ module CI
 
     private
 
-    def populate_keyring
+    def populate_kde_keyring
       make_dir("#{@dir}/upstream/")
-      FileUtils.cp('/usr/share/keyrings/kde-release-keyring.asc', "#{@dir}/upstream/signing-key.asc", force: true)
+      FileUtils.cp('/usr/share/keyrings/kde-release-keyring.asc', "#{@dir}/upstream/signing-key.asc")
     end
 
     def make_dir(destdir)
@@ -97,6 +96,7 @@ module CI
     def maybe_mangle(&block)
       orig_data = File.read(@watchfile)
       File.write(@watchfile, mangle_url(orig_data)) if @mangle_download
+      populate_kde_keyring()
       block.yield
     ensure
       File.write(@watchfile, orig_data)


### PR DESCRIPTION
force:true is the default for Fileutils.cp and thus causes an error