### PR TITLE
add openjdk-17-jre to setup the repo as it is not the default on jammy

### DIFF
--- a/nci/lib/setup_repo.rb
+++ b/nci/lib/setup_repo.rb
@@ -59,7 +59,7 @@ module NCI
     # Make sure we have the latest pkg-kde-tools, not whatever is in the image.
     return unless with_install
 
-    deps = %w[pkg-kde-tools pkg-kde-tools-neon debhelper cmake quilt dh-python dh-translations]
+    deps = %w[pkg-kde-tools pkg-kde-tools-neon debhelper cmake quilt dh-python dh-translations openjdk-17-jre]
     deps << 'kde-release-keyring' unless ENV.fetch('JOB_NAME').include?('kde-keyring')
     raise 'failed to install deps' unless Apt.install(deps)
     


### PR DESCRIPTION
revert when the builders are all updated noble