### PR TITLE
due to new ubuntu changes,  cloud-init status --wait can now exit on …

### DIFF
--- a/mgmt/digital_ocean/deploy.sh
+++ b/mgmt/digital_ocean/deploy.sh
@@ -8,7 +8,7 @@ set -ex
 export DEBIAN_FRONTEND=noninteractive
 
 # Disable bloody apt automation crap locking the database.
-cloud-init status --wait --long
+#cloud-init status --wait --long
 systemctl disable --now apt-daily.timer
 systemctl disable --now apt-daily.service
 systemctl mask apt-daily.service


### PR DESCRIPTION
…error code 2

even when it's just a warning about invalid network configs from digital ocean and thus the job falls over