### PR TITLE
add the curly brackets ruby on noble requires

### DIFF
--- a/ci/pangea_dput
+++ b/ci/pangea_dput
@@ -95,7 +95,7 @@ end
 # Set the timeout to 15 minutes to allow upload of large packages such as
 # firefox and publishing of excessively large repositories.
 Faraday.default_connection_options =
-  Faraday::ConnectionOptions.new({timeout: 15 * 60})
+  Faraday::ConnectionOptions.new(request: {timeout: 15 * 60})
 
 Aptly::Ext::Remote.connect(options.gateway) do
   repos = options.repos.collect { |name| Aptly::Repository.get(name) }

--- a/ci/pangea_dput
+++ b/ci/pangea_dput
@@ -95,7 +95,7 @@ end
 # Set the timeout to 15 minutes to allow upload of large packages such as
 # firefox and publishing of excessively large repositories.
 Faraday.default_connection_options =
-  Faraday::ConnectionOptions.new(timeout: 15 * 60)
+  Faraday::ConnectionOptions.new({timeout: 15 * 60})
 
 Aptly::Ext::Remote.connect(options.gateway) do
   repos = options.repos.collect { |name| Aptly::Repository.get(name) }

--- a/nci/i386_install_check.rb
+++ b/nci/i386_install_check.rb
@@ -22,7 +22,7 @@ NCI.add_repo_key!
 
 # Force a higher time out. We are going to do one or two heavy queries.
 Faraday.default_connection_options =
-  Faraday::ConnectionOptions.new({timeout: 15 * 60})
+  Faraday::ConnectionOptions.new(request: {timeout: 15 * 60})
 
 Aptly.configure do |config|
   config.uri = URI::HTTPS.build(host: 'archive-api.neon.kde.org')

--- a/nci/install_check.rb
+++ b/nci/install_check.rb
@@ -39,7 +39,7 @@ NCI.add_repo_key!
 
 # Force a higher time out. We are going to do one or two heavy queries.
 Faraday.default_connection_options =
-  Faraday::ConnectionOptions.new({timeout: 15 * 60})
+  Faraday::ConnectionOptions.new(request: {timeout: 15 * 60})
 
 Aptly.configure do |config|
   config.uri = URI::HTTPS.build(host: 'archive-api.neon.kde.org')

--- a/nci/repo_cleanup.rb
+++ b/nci/repo_cleanup.rb
@@ -34,7 +34,7 @@ end
 if $PROGRAM_NAME == __FILE__ || ENV.include?('PANGEA_TEST_EXECUTION')
   # SSH tunnel so we can talk to the repo
   Faraday.default_connection_options =
-    Faraday::ConnectionOptions.new({timeout: 15 * 60})
+    Faraday::ConnectionOptions.new(request: {timeout: 15 * 60})
   Aptly::Ext::Remote.neon do
     RepoCleaner.clean(%w[unstable stable] +
                       RepoNames.all('unstable') + RepoNames.all('stable'),

--- a/nci/repo_snapshot_testing.rb
+++ b/nci/repo_snapshot_testing.rb
@@ -50,7 +50,7 @@ Subject: #{prefix} Snapshot Done
 end
 
 Faraday.default_connection_options =
-  Faraday::ConnectionOptions.new({timeout: 15 * 60})
+  Faraday::ConnectionOptions.new(request: {timeout: 15 * 60})
 
 # SSH tunnel so we can talk to the repo
 Aptly::Ext::Remote.neon do

--- a/nci/repo_snapshot_user.rb
+++ b/nci/repo_snapshot_user.rb
@@ -50,7 +50,7 @@ Subject: #{prefix} Snapshot Done
 end
 
 Faraday.default_connection_options =
-  Faraday::ConnectionOptions.new({timeout: 15 * 60})
+  Faraday::ConnectionOptions.new(request: {timeout: 15 * 60})
 
 # SSH tunnel so we can talk to the repo
 Aptly::Ext::Remote.neon do

--- a/xci/repo_cleanup.rb
+++ b/xci/repo_cleanup.rb
@@ -26,7 +26,7 @@ require_relative '../lib/aptly-ext/repo_cleaner'
 
 # SSH tunnel so we can talk to the repo
 Faraday.default_connection_options =
-  Faraday::ConnectionOptions.new(timeout: 15 * 60)
+  Faraday::ConnectionOptions.new(request: {timeout: 15 * 60})
 
 socket_uri = URI('ssh://aptly@localhost/home/aptly/aptly.socket')
 Aptly::Ext::Remote.connect(socket_uri) do


### PR DESCRIPTION
Faraday::ConnectionOptions.new wants ({*****: *}) extra curly brackets to pass through the timeout

https://bugs.ruby-lang.org/issues/16806