### PR TITLE
fix the logic check for signing-key.asc

### DIFF
--- a/lib/ci/tar-fetcher/watch.rb
+++ b/lib/ci/tar-fetcher/watch.rb
@@ -103,7 +103,9 @@ module CI
       File.write(@watchfile, orig_data)
       # restore keyring only if one already exists, we don't want to create one if
       # there wasn't one in the first place
-      if File.file?("#{@dir}/debian/upstream/signing-key.asc")
+      if orig_key_data.nil?
+        return
+      else
         File.write("#{@dir}/debian/upstream/signing-key.asc", orig_key_data)
       end
     end


### PR DESCRIPTION
check against orig_key_data being nil and exit if true, reinstate the original key if it is false and had actually did exist